### PR TITLE
Conditional imports to support operating with `pydantic>2` installed

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,9 +31,9 @@ jobs:
 
       - name: Run tests
         env:
-          PREFECT_ORION_DATABASE_CONNECTION_URL: "sqlite+aiosqlite:///./orion-tests.db"
+          PREFECT_API_DATABASE_CONNECTION_URL: "sqlite+aiosqlite:///./orion-tests.db"
         run: |
-          prefect orion database reset -y
+          prefect server database reset -y
           coverage run --branch -m pytest tests -vv
           coverage report
 

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -29,6 +29,6 @@ jobs:
           python -m pip install --upgrade --upgrade-strategy eager -e ".[dev]"
       - name: Run tests
         env:
-          PREFECT_ORION_DATABASE_CONNECTION_URL: "sqlite+aiosqlite:///./orion-tests.db"
+          PREFECT_API_DATABASE_CONNECTION_URL: "sqlite+aiosqlite:///./orion-tests.db"
         run: |
           pytest tests -vv

--- a/prefect_slack/credentials.py
+++ b/prefect_slack/credentials.py
@@ -5,7 +5,13 @@ from typing import Optional
 from prefect.blocks.core import Block
 from prefect.blocks.notifications import NotificationBlock
 from prefect.utilities.asyncutils import sync_compatible
-from pydantic import Field, SecretStr
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import Field, SecretStr
+else:
+    from pydantic import Field, SecretStr
+
 from slack_sdk.web.async_client import AsyncWebClient
 from slack_sdk.webhook.async_client import AsyncWebhookClient
 


### PR DESCRIPTION
Following the compatibility work we've done in `prefect`, we also want to apply the
same compatibility changes to all Prefect-maintained collections.  We're following the
convention that Prefect will always use `pydantic<2` idioms, leaning on the
`pydantic.v1` module of `pydantic>2` to aid us in this.  With these changes, we can
operate normally regardless of the installed version.

Until `prefect` fully deprecates `pydantic` versions below 2.0, we'll continue to
maintain that constraint of using only v1 idioms.

This is part of a series of identical PRs for all of our maintained collections.