### PR TITLE
'Update the pin on `prefect` version'

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-prefect>=2.0.0
+prefect >=2.13.5
 slack-sdk>=3.15.1
 aiohttp>=3.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-prefect >=2.13.5
+prefect>=2.13.5
 slack-sdk>=3.15.1
 aiohttp>=3.8.1


### PR DESCRIPTION
As part of our work adding support for Pydantic 2, we removed its pin in 
`prefect`'s `requirements.txt`. This means that it's possible to have 
`prefect`, `pydantic>=2`, and any version of this collection installed. But, 
the collection(s) only support `pydantic>=2` in their latest versions. This 
PR adds a pin on the collection's `requirements.txt` to make sure that it is 
only installed with the correct version `prefect` that supports `pydantic>=2`