### PR TITLE
Introducing conditional support for `NotificationBlock.raise_on_failure`

### DIFF
--- a/prefect_slack/credentials.py
+++ b/prefect_slack/credentials.py
@@ -108,4 +108,17 @@ class SlackWebhook(NotificationBlock):
         Sends a message to the Slack channel.
         """
         client = self.get_client()
-        await client.send(text=body)
+
+        response = await client.send(text=body)
+
+        # prefect>=2.17.2 added a means for notification blocks to raise errors on
+        # failures. This is not available in older versions, so we need to check if the
+        # private base class attribute exists before using it.
+        if getattr(self, "_raise_on_failure", False):
+            try:
+                from prefect.blocks.abstract import NotificationError
+            except ImportError:
+                NotificationError = Exception
+
+            if response.status_code >= 400:
+                raise NotificationError(f"Failed to send message: {response.body}")

--- a/prefect_slack/credentials.py
+++ b/prefect_slack/credentials.py
@@ -114,7 +114,7 @@ class SlackWebhook(NotificationBlock):
         # prefect>=2.17.2 added a means for notification blocks to raise errors on
         # failures. This is not available in older versions, so we need to check if the
         # private base class attribute exists before using it.
-        if getattr(self, "_raise_on_failure", False):
+        if getattr(self, "_raise_on_failure", False):  # pragma: no cover
             try:
                 from prefect.blocks.abstract import NotificationError
             except ImportError:

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,5 +1,8 @@
+from unittest.mock import AsyncMock
+
+import pytest
 from slack_sdk.web.async_client import AsyncWebClient
-from slack_sdk.webhook.async_client import AsyncWebhookClient
+from slack_sdk.webhook.async_client import AsyncWebhookClient, WebhookResponse
 
 from prefect_slack import SlackCredentials, SlackWebhook
 
@@ -13,3 +16,51 @@ def test_slack_webhook():
         SlackWebhook(url="https://hooks.slack.com/xxxx").get_client(),
         AsyncWebhookClient,
     )
+
+
+@pytest.mark.skipif(
+    condition=not hasattr(SlackWebhook, "raise_on_failure"),
+    reason="The raise_on_failure option is only implemented in prefect>=2.17.2",
+)
+async def test_slack_webhook_block_does_not_raise_on_success(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        AsyncWebhookClient,
+        "send",
+        AsyncMock(
+            return_value=WebhookResponse(
+                url="http://wherever", status_code=222, body="yay", headers={}
+            )
+        ),
+    )
+    block = SlackWebhook(url="http://wherever")
+
+    with block.raise_on_failure():
+        await block.notify("hello", "world")
+
+
+@pytest.mark.skipif(
+    condition=not hasattr(SlackWebhook, "raise_on_failure"),
+    reason="The raise_on_failure option is only implemented in prefect>=2.17.2",
+)
+async def test_slack_webhook_block_handles_raise_on_failure(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        AsyncWebhookClient,
+        "send",
+        AsyncMock(
+            return_value=WebhookResponse(
+                url="http://wherever", status_code=400, body="woops", headers={}
+            )
+        ),
+    )
+
+    from prefect.blocks.abstract import NotificationError
+
+    block = SlackWebhook(url="http://wherever")
+
+    with pytest.raises(NotificationError, match="Failed to send message: woops"):
+        with block.raise_on_failure():
+            await block.notify("hello", "world")

--- a/tests/test_notification_block.py
+++ b/tests/test_notification_block.py
@@ -1,0 +1,54 @@
+from unittest.mock import AsyncMock
+
+import pytest
+from slack_sdk.webhook.async_client import AsyncWebhookClient, WebhookResponse
+
+from prefect_slack import SlackWebhook
+
+
+@pytest.mark.skipif(
+    condition=not hasattr(SlackWebhook, "raise_on_failure"),
+    reason="The raise_on_failure option is only implemented in prefect>=2.17.2",
+)
+async def test_slack_webhook_block_does_not_raise_on_success(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        AsyncWebhookClient,
+        "send",
+        AsyncMock(
+            return_value=WebhookResponse(
+                url="http://wherever", status_code=222, body="yay", headers={}
+            )
+        ),
+    )
+    block = SlackWebhook(url="http://wherever")
+
+    with block.raise_on_failure():
+        await block.notify("hello", "world")
+
+
+@pytest.mark.skipif(
+    condition=not hasattr(SlackWebhook, "raise_on_failure"),
+    reason="The raise_on_failure option is only implemented in prefect>=2.17.2",
+)
+async def test_slack_webhook_block_handles_raise_on_failure(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        AsyncWebhookClient,
+        "send",
+        AsyncMock(
+            return_value=WebhookResponse(
+                url="http://wherever", status_code=400, body="woops", headers={}
+            )
+        ),
+    )
+
+    from prefect.blocks.abstract import NotificationError
+
+    block = SlackWebhook(url="http://wherever")
+
+    with pytest.raises(NotificationError, match="Failed to send message: woops"):
+        with block.raise_on_failure():
+            await block.notify("hello", "world")


### PR DESCRIPTION
In prefect>=2.17.2, we'll have a new capability to instruct notification blocks
to raise errors when they have a problem sending.  Here, we use an duck-typing
and conditional import approach to testing for this in the SlackWebhook block.

<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Closes

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-slack/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
